### PR TITLE
fix browser mobility check

### DIFF
--- a/src/www/pionir/index.php
+++ b/src/www/pionir/index.php
@@ -87,7 +87,8 @@ class gIndexPage {
      */
     function detectMobile() {
         $user_agent = $_SERVER["HTTP_USER_AGENT"];
-        return preg_match("/(applewebkit|phone|pie|tablet|up\.browser|up\.link|webos|wos)/i"
+        return preg_match("/(android|avantgo|blackberry|bolt|boost|cricket|docomo
+			|fone|hiptop|mini|mobi|palm|phone|pie|tablet|up\.browser|up\.link|webos|wos)/i"
             , $user_agent );
     }
     


### PR DESCRIPTION
The match "applewebkit" was causing false positive at least with Chromium/Google Chrome Browser.  Here is an updated list of keywords recommended by https://www.geeksforgeeks.org/how-to-detect-a-mobile-device-using-php.